### PR TITLE
Rename to test-collector-curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Buildkite Collector for JUnit
+# Buildkite Collector for Curl
 
-A [Buildkite Test Analytics](https://buildkite.com/test-analytics) collector for JUnit files that uses `bash` and `curl` ✨
+A [Buildkite Test Analytics](https://buildkite.com/test-analytics) collector that uses `curl` to upload JSON and JUnit files ✨
 
 📦 **Supported CI systems:** Buildkite, GitHub Actions, CircleCI, and others via the `BUILDKITE_ANALYTICS_*` environment variables.
 
@@ -9,16 +9,33 @@ A [Buildkite Test Analytics](https://buildkite.com/test-analytics) collector for
 Using curl from within your build scripts:
 
 ```sh
+# For a JUnit file
 cat junit.xml | \
   BUILDKITE_ANALYTICS_TOKEN=xyz \
-  bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/test-collector-junit/main/test-collector`"
+  bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/test-collector-curl/main/test-collector`" \
+    --format junit
+    
+# For a Test Analytics JSON file
+cat test-results.json | \
+  BUILDKITE_ANALYTICS_TOKEN=xyz \
+  bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/test-collector-curl/main/test-collector`" \
+    --format json
 ```
+
+See the [Importing JSON](https://buildkite.com/docs/test-analytics/importing-json) and [Importing JUnit XML](https://buildkite.com/docs/test-analytics/importing-junit-xml) documentation for more details.
 
 <!-- Using Docker:
 
 ```sh
+# For a JUnit file
 cat junit.xml | \
-  docker run -e BUILDKITE_ANALYTICS_TOKEN=xyz buildkite-test-collector
+  docker run -e BUILDKITE_ANALYTICS_TOKEN=xyz buildkite-test-collector \
+    --format junit
+
+# For a Test Analytics JSON file
+cat test-results.json | \
+  docker run -e BUILDKITE_ANALYTICS_TOKEN=xyz buildkite-test-collector \
+    --format json
 ```
 
 When using Docker, make sure to pass through the required environment variables for your CI system. For example, use the following command if you're running it within a Buildkite job:
@@ -33,8 +50,11 @@ cat junit.xml | \
     -e BUILDKITE_COMMIT \
     -e BUILDKITE_MESSAGE \
     -e BUILDKITE_BUILD_URL \
-    buildkite-test-collector
-``` -->
+    buildkite-test-collector \
+      --format junit
+```
+
+-->
 
 ## ⚒ Developing
 
@@ -54,7 +74,11 @@ Useful resources for developing collectors include the [Buildkite Test Analytics
 
 ## 👩‍💻 Contributing
 
+<<<<<<< HEAD
 Bug reports and pull requests are welcome on GitHub at https://github.com/buildkite/test-collector-junit
+=======
+Bug reports and pull requests are welcome on GitHub at https://github.com/buildkite/test-collector-curl
+>>>>>>> bfb9c7f (Update README.md)
 
 ## 📜 License
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Buildkite Collector for Curl
+# Buildkite Collector for curl
 
 A [Buildkite Test Analytics](https://buildkite.com/test-analytics) collector that uses `curl` to upload JSON and JUnit files ✨
 
@@ -74,11 +74,7 @@ Useful resources for developing collectors include the [Buildkite Test Analytics
 
 ## 👩‍💻 Contributing
 
-<<<<<<< HEAD
-Bug reports and pull requests are welcome on GitHub at https://github.com/buildkite/test-collector-junit
-=======
 Bug reports and pull requests are welcome on GitHub at https://github.com/buildkite/test-collector-curl
->>>>>>> bfb9c7f (Update README.md)
 
 ## 📜 License
 

--- a/test-collector
+++ b/test-collector
@@ -2,7 +2,7 @@
 
 set -e
 
-BUILDKITE_ANALYTICS_NAME="collector-junit"
+BUILDKITE_ANALYTICS_NAME="test-collector-curl"
 BUILDKITE_ANALYTICS_VERSION="0.1"
 
 echo -e "\033[33m     _ _   _       _ _      ____      _ _           _
@@ -11,7 +11,7 @@ echo -e "\033[33m     _ _   _       _ _      ____      _ _           _
 | |_| | |_| | | | | | |_  | |__| (_) | | |  __| (__| || (_) | |
  \___/ \___/|_| |_|_|\__|  \____\___/|_|_|\___|\___|\__\___/|_|
 
-Buildkite Test Analytics: JUnit Collector
+Buildkite Test Analytics: curl Collector
 Version: $BUILDKITE_ANALYTICS_VERSION
 \033[0m"
 


### PR DESCRIPTION
This is a draft PR to investigate renaming this to something more generic, test-collector-curl, so we can support uploading both JUnit and JSON files.

Outright using the word `curl` instead of hiding it, means that it can be a nice reference for people wanting to just do it themselves. Also looking at `wget`, it doesn't have as many useful options for `curl` and would be much tricker to use, so we can probably just leave it out permanently?

You can preview the readme in-situ here: https://github.com/buildkite/test-collector-junit/tree/rename-to-test-collector-curl

Recommending people do a curl from the main branch still makes me nervous… it should at least be pinned to a tag.

And if #2 gets merged, then we could also provide instructions for just copying the shell file into their own repos.